### PR TITLE
fix: add `last-updated` to default secondary info

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_SECONDARY_INFO = [
   "entity-id",
   "last-changed",
+  "last-updated",
   "last-triggered",
   "position",
   "tilt-position",


### PR DESCRIPTION
This should fix #36 as far as I can tell. Note I have not tested the fix because I don't know how.